### PR TITLE
Better handle booleans.

### DIFF
--- a/excavator/utils.py
+++ b/excavator/utils.py
@@ -21,6 +21,7 @@ def env_string(name, default='', required=False):
 
 
 TRUE_VALUES = set((
+    True,
     'True',
     'true',
 ))
@@ -29,7 +30,7 @@ TRUE_VALUES = set((
 def env_bool(name, truthy_values=TRUE_VALUES, required=False, default=None):
     """
     Return a boolean value derived from an environmental variable.  This is
-    done via string comparison.
+    done via string comparison (Or if the value is `True`).
     """
     env_value = env_string(name, required=required, default=default)
     return env_value in TRUE_VALUES

--- a/tests/test_env_bool.py
+++ b/tests/test_env_bool.py
@@ -55,14 +55,13 @@ def test_env_bool_when_missing_and_default_provided():
     """
     assert 'TEST_BOOLEAN_ENV_VARIABLE' not in os.environ
 
-    actual = env_bool('TEST_BOOLEAN_ENV_VARIABLE', default='True')
+    actual = env_bool('TEST_BOOLEAN_ENV_VARIABLE', default=True)
     assert actual is True
 
 
 def test_that_required_and_default_are_mutually_exclusive():
     """
-    Test that when the env variable is not set and a default is provided, the
-    default is used.
+    Test that when `required` and `default` are both set, raises a ValueError.
     """
     with pytest.raises(ValueError):
-        env_bool('TEST_BOOLEAN_ENV_VARIABLE', required=True, default='True')
+        env_bool('TEST_BOOLEAN_ENV_VARIABLE', required=True, default=True)


### PR DESCRIPTION
`env_boolean('foo', default=True)` works now, as it should.

![siberian-fox-in-snow](https://cloud.githubusercontent.com/assets/925990/5365558/6a5afb3e-7faa-11e4-9722-03a833e49611.jpg)
