### PR TITLE
enable docker builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 python:
   - "2.7"
+sudo: false
 env:
   global:
     - PIP_DOWNLOAD_CACHE=$HOME/.pip_cache


### PR DESCRIPTION
### What is the problem / feature ?

Docker builds are avaliable and not being used
### How did it get fixed / implemented ?

set `sudo: false` in `.travis.yml` to enable docker builds.
### How can someone test / see it ?

See builds are faster.

_Here is a cute animal picture for your troubles..._

![209581-socks-the-shetland-pony-in-christmas-advert-for-visitscotlnad](https://cloud.githubusercontent.com/assets/824194/5507859/6309d82a-8764-11e4-8e23-f4c226bb6ce0.jpg)
