### PR TITLE
Piper/fix env int default handling

### DIFF
--- a/excavator/__init__.py
+++ b/excavator/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '1.2.0'
+__version__ = '1.3.0'
 
 from .utils import (  # NOQA
     env_string,

--- a/excavator/utils.py
+++ b/excavator/utils.py
@@ -64,8 +64,13 @@ def env_list(name, separator=',', required=False, default=empty):
     done by splitting the string value from the environment on a given
     separator.
     """
-    value = get_env_value(name, required=required, default=default)
+    if required and default is not empty:
+        raise ValueError("Using `default` with `required=True` is invalid")
+
+    value = get_env_value(name, required=required, default=empty)
     if value is empty:
+        if default is not empty:
+            return default
         return []
     # wrapped in list to force evaluation in python 3
     return list(filter(bool, [v.strip() for v in value.split(separator)]))
@@ -78,8 +83,13 @@ def env_int(name, required=False, default=empty):
     environment, a `TypeError` will be raised since we don't want to guess
     about a sensible default.
     """
-    value = get_env_value(name, required=required, default=default)
+    if required and default is not empty:
+        raise ValueError("Using `default` with `required=True` is invalid")
+
+    value = get_env_value(name, required=required, default=empty)
     if value is empty:
+        if default is not empty:
+            return default
         raise ValueError(
             "`env_int` requires either a default value to be specified, or for "
             "the variable to be present in the environment"
@@ -92,10 +102,9 @@ def env_timestamp(name, default=empty, required=False):
         raise ValueError("Using `default` with `required=True` is invalid")
 
     value = get_env_value(name, required=required, default=empty)
-    # change datetime.datetime to time, return time.struct_time type
-    if default is not empty and value is empty:
-        return default
     if value is empty:
+        if default is not empty:
+            return default
         raise ValueError(
             "`env_timestamp` requires either a default value to be specified, or "
             "for the variable to be present in the environment"
@@ -117,10 +126,9 @@ def env_iso8601(name, default=empty, required=False):
         raise ValueError("Using `default` with `required=True` is invalid")
 
     value = get_env_value(name, required=required, default=empty)
-    # change datetime.datetime to time, return time.struct_time type
-    if default is not empty and value is empty:
-        return default
     if value is empty:
+        if default is not empty:
+            return default
         raise ValueError(
             "`env_iso8601` requires either a default value to be specified, or "
             "for the variable to be present in the environment"

--- a/tests/test_env_int.py
+++ b/tests/test_env_int.py
@@ -51,8 +51,6 @@ def test_env_int_when_missing_and_required_is_error():
     'default,expected',
     (
         (1, 1),
-        ('1', 1),
-        ('-1', -1),
         (-1, -1),
     )
 )
@@ -73,3 +71,10 @@ def test_that_required_and_default_are_mutually_exclusive():
     """
     with pytest.raises(ValueError):
         env_int('TEST_INT_ENV_VARIABLE', required=True, default=1)
+
+
+def test_that_a_non_integer_default_value_is_allowed():
+    assert 'TEST_INT_ENV_VARIABLE' not in os.environ
+
+    actual = env_int('TEST_INT_ENV_VARIABLE', default=None)
+    assert actual is None

--- a/tests/test_env_list.py
+++ b/tests/test_env_list.py
@@ -56,7 +56,7 @@ def test_env_list_with_default_value():
     # sanity check
     assert 'TEST_LIST_ENV_VARIABLE' not in os.environ
 
-    actual = env_list('TEST_LIST_ENV_VARIABLE', default='a,b,c')
+    actual = env_list('TEST_LIST_ENV_VARIABLE', default=['a', 'b', 'c'])
     assert actual == ['a', 'b', 'c']
 
 


### PR DESCRIPTION
### What is the problem / feature ?

Both `env_int` and `env_list` are written in such a way that passing in a `default` value that isn't able to be processed the same way as the string returned from the environment causes an error.  This isn't good since it's nice to be able to do `excavator.env_int('SOME_VAR', default=None)`.
### How did it get fixed / implemented ?

Changed both to return the `default` value unmodified.
### How can someone test / see it ?

See that `env_list` and `env_int` don't muck with the value passed into the `default` keyword.

_Here is a cute animal picture for your troubles..._

![goatie](https://cloud.githubusercontent.com/assets/824194/6833337/cffd8dae-d2f1-11e4-8c13-f5dec7bfa410.jpg)
